### PR TITLE
Update pyodbc version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "pendulum==1.2.0",
         "singer-python==5.9.0",
         "sqlalchemy<2.0.0",
-        "pyodbc==4.0.26",
+        "pyodbc==4.0.32",
         "backoff==1.8.0",
         "MarkupSafe==2.0.1",
         "jinja2==2.11.3",

--- a/tap_mssql/connection.py
+++ b/tap_mssql/connection.py
@@ -32,29 +32,6 @@ def connect_with_backoff(connection):
     return connection
 
 
-def decode_sketchy_utf16(raw_bytes):
-    """Updates the output handling where malformed unicode is received from MSSQL"""
-    s = raw_bytes.decode("utf-16le", "ignore")
-    try:
-        n = s.index("\u0000")
-        s = s[:n]  # respect null terminator
-    except ValueError:
-        pass
-    return s
-
-
-def modify_ouput_converter(conn):
-
-    prev_converter = conn.connection.get_output_converter(pyodbc.SQL_WVARCHAR)
-    conn.connection.add_output_converter(pyodbc.SQL_WVARCHAR, decode_sketchy_utf16)
-
-    return prev_converter
-
-
-def revert_ouput_converter(conn, prev_converter):
-    conn.connection.add_output_converter(pyodbc.SQL_WVARCHAR, prev_converter)
-
-
 def get_azure_sql_engine(config) -> Engine:
     """The All-Purpose SQL connection object for the Azure Data Warehouse."""
 

--- a/tap_mssql/sync_strategies/full_table.py
+++ b/tap_mssql/sync_strategies/full_table.py
@@ -90,9 +90,6 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version
 
         params = {}
 
-        if catalog_entry.tap_stream_id == "dbo-InputMetadata":
-            prev_converter = modify_ouput_converter(open_conn)
-
         columns.sort()
         select_sql = common.fast_sync_generate_select_sql(catalog_entry, columns)
 
@@ -124,9 +121,6 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version
         json_object = json.dumps(singer_message) 
         sys.stdout.write(str(json_object) + '\n')
         sys.stdout.flush()
-
-        if catalog_entry.tap_stream_id == "dbo-InputMetadata":
-            revert_ouput_converter(open_conn, prev_converter)
 
     # clear max pk value and last pk fetched upon successful sync
     singer.clear_bookmark(state, catalog_entry.tap_stream_id, "max_pk_values")

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -232,9 +232,6 @@ class log_based_sync:
         )
         with self.mssql_conn.connect() as open_conn:
 
-            if self.catalog_entry.tap_stream_id == "dbo-InputMetadata":
-                prev_converter = modify_ouput_converter(open_conn)
-
             results = open_conn.execute(ct_sql_query)
 
             row = results.fetchone()
@@ -307,9 +304,6 @@ class log_based_sync:
                     )
 
             singer.write_message(singer.StateMessage(value=copy.deepcopy(self.state)))
-
-            if self.catalog_entry.tap_stream_id == "dbo-InputMetadata":
-                revert_ouput_converter(open_conn, prev_converter)
 
     def _build_ct_sql_query(self, key_properties):
         """Using Selected columns, return an SQL query to select updated records from Change Tracking"""


### PR DESCRIPTION
- Update version to 4.0.32 to fix [Unicode decode error](https://learn.microsoft.com/en-us/azure/databricks/dev-tools/pyodbc#unicode-decode-error):
` 'utf-16-le' codec can't decode bytes in position 3998-3999: unexpected end of data`
- Remove InputMetadata prev_converter logic to handle the above error that no longer persists
